### PR TITLE
Add unicode flags to language links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ my co:radar - anonymous. solidary. safe.
 
 <img src="https://github.com/generaliinformatik/mycoradar/raw/master/docs/images/logo_small.png" alt="logo_small" width="100%"/>
 
-[Deutsch](README_de.md)
+[🇩🇪 Deutsche Übersetzung](README_de.md)
 
 An innovative solution for the solidary protection of our community from COVID-19. Anonymous use guaranteed and safe for your health.
 

--- a/README_de.md
+++ b/README_de.md
@@ -4,7 +4,7 @@ my co:radar - anonym. solidarisch. sicher.
 
 <img src="https://github.com/generaliinformatik/mycoradar/raw/master/docs/images/logo_small.png" alt="logo_small" width="100%"/>
 
-[English](README.md)
+[🇬🇧 English translation](README.md)
 
 Eine innovative Lösung für den solidarischen Schutz unserer Gemeinschaft. Anonyme Nutzung sichergestellt und sicher für Deine Gesundheit.
 


### PR DESCRIPTION
This PR adds some minor bells and whistles, i.e. unicode flags before the language links.